### PR TITLE
remove private field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "devDependencies": {
     "@types/papaparse": "^5.0.1",
     "@types/puppeteer": "^1.20.1",
-    "husky": "^3.0.8"
+    "husky": "^3.0.8",
+    "prettier": "^1.18.2"
   },
   "husky": {
     "hooks": {
@@ -41,6 +42,5 @@
     "scraper",
     "scraping"
   ],
-  "private": true,
   "license": "MIT"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -588,6 +588,11 @@ please-upgrade-node@^3.2.0:
   dependencies:
     semver-compare "^1.0.0"
 
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"


### PR DESCRIPTION
Implements #1 
You should now be able to type `npm publish` or `yarn publish` and publish it to `npmjs.com`.
I have also added `prettier` to the `devDependencies`
happy hacktoberfest! 🎃